### PR TITLE
:bug: Fix printing that doesn't need to be called

### DIFF
--- a/src/get_current_infos/get_no_error_infos.c
+++ b/src/get_current_infos/get_no_error_infos.c
@@ -54,7 +54,6 @@ n4s_returns_t *get_no_error_infos(void)
 
     if (infos == NULL)
         return NULL;
-    my_putstr("GET_INFO_SIMTIME\n");
     read = getline(&line, &len, stdin);
     if (read == -1)
         return NULL;


### PR DESCRIPTION
Just the no_error function that doesn't need to call something